### PR TITLE
Underscores.me: Use hyphenated slug for textdomains.

### DIFF
--- a/plugins/underscoresme-generator/underscoresme-generator.php
+++ b/plugins/underscoresme-generator/underscoresme-generator.php
@@ -213,9 +213,9 @@ class Underscores_Generator_Plugin {
 		$slug = str_replace( '-', '_', $this->theme['slug'] );
 
 		// Regular treatment for all other files.
-		$contents = str_replace( "_s-", $slug . '-', $contents );
-		$contents = str_replace( "'_s'", sprintf( "'%s'",  $slug ), $contents );
-		$contents = str_replace( "_s_", $slug . '_', $contents );
+		$contents = str_replace( "_s-", sprintf( "'%s-",  $this->theme['slug'] ), $contents ); // Script/style handles.
+		$contents = str_replace( "'_s'", sprintf( "'%s'",  $this->theme['slug'] ), $contents ); // Textdomains.
+		$contents = str_replace( "_s_", $slug . '_', $contents ); // Function names.
 		$contents = preg_replace( '/\b_s\b/', $this->theme['name'], $contents );
 		return $contents;
 	}


### PR DESCRIPTION
...and handle prefixes.

Pull request for #6.
