### PR TITLE
Update feature list language to match _s readme.

### DIFF
--- a/templates/homepage.php
+++ b/templates/homepage.php
@@ -28,13 +28,13 @@ get_header(); ?>
 					<ul id="features">
 						<li>A just right amount of lean, well-commented, modern, HTML5 templates.</li>
 						<li>A helpful 404 template.</li>
-						<li>An optional sample custom header implementation in <code>inc/custom-header.php</code></li>
+						<li>An optional sample custom header implementation in <code>inc/custom-header.php</code>.</li>
 						<li>Custom template tags in <code>inc/template-tags.php</code> that keep your templates clean and neat and prevent code duplication.</li>
 						<li>Some small tweaks in <code>inc/extras.php</code> that can improve your theming experience.</li>
 						<li>A script at <code>js/navigation.js</code> that makes your menu a toggled dropdown on small screens (like your phone), ready for CSS artistry.</li>
-						<li>2 sample CSS layouts in <code>layouts/</code>: A sidebar on the right side of your content and a sidebar on the left side of your content.</li>
+						<li>2 sample CSS layouts in <code>layouts</code> for a sidebar on either side of your content.</li>
 						<li>Smartly organized starter CSS in <code>style.css</code> that will help you to quickly get your design off the ground.</li>
-						<li>The GPL license in license.txt. Use it to make something cool.</li>
+						<li>Licensed under GPLv2 or later. :) Use it to make something cool.</li>
 					</ul><!-- #features -->
 				</div><!-- .wrap -->
 			</section><!-- #about -->

--- a/templates/homepage.php
+++ b/templates/homepage.php
@@ -32,7 +32,7 @@ get_header(); ?>
 						<li>Custom template tags in <code>inc/template-tags.php</code> that keep your templates clean and neat and prevent code duplication.</li>
 						<li>Some small tweaks in <code>inc/extras.php</code> that can improve your theming experience.</li>
 						<li>A script at <code>js/navigation.js</code> that makes your menu a toggled dropdown on small screens (like your phone), ready for CSS artistry.</li>
-						<li>2 sample CSS layouts in <code>layouts</code> for a sidebar on either side of your content.</li>
+						<li>2 sample CSS layouts in <code>layouts/</code> for a sidebar on either side of your content.</li>
 						<li>Smartly organized starter CSS in <code>style.css</code> that will help you to quickly get your design off the ground.</li>
 						<li>Licensed under GPLv2 or later. :) Use it to make something cool.</li>
 					</ul><!-- #features -->


### PR DESCRIPTION
As I mentioned in Automattic/_s#533, I’ve updated the feature list to fix the differences between the main repo’s list and the list on http://underscores.me.

What I didn’t include, though, were instructions that are in the _s readme about how to implement features, because I didn’t think they were necessary on the site. Once a user has downloaded a version of _s, they probably won’t return to the website to figure out how to implement a feature, being more likely to turn to the repo itself.

If it seems necessary to include the instructions on the website, then I’ll do that, too.
