### PR TITLE
Added transition fix to stop annoying overflow bug in webkit

### DIFF
--- a/style.css
+++ b/style.css
@@ -439,6 +439,10 @@ a:active {
 	text-align: center;
 	color: #DFDFD0;
 	overflow: hidden;
+	-webkit-backface-visibility: hidden;
+	-moz-backface-visibility: hidden;
+	-webkit-transform: translate3d(0, 0, 0);
+	-moz-transform: translate3d(0, 0, 0);
 }
 
 .site-header .site-title span.site-header-bubblewrap:before {


### PR DESCRIPTION
This stops the annoying problem in webkit browsers where the actual _ before the S momentarily breaks the boundary of the circle during the transition on hover (the moz-fix is in as well in case it's ever needed.)
