### PR TITLE
Include sass/ in check for style.scss, fix #34

### DIFF
--- a/plugins/underscoresme-generator/underscoresme-generator.php
+++ b/plugins/underscoresme-generator/underscoresme-generator.php
@@ -172,7 +172,7 @@ class Underscores_Generator_Plugin {
 			return $contents;
 
 		// Special treatment for style.css
-		if ( in_array( $filename, array( 'style.css', 'style.scss' ), true ) ) {
+		if ( in_array( $filename, array( 'style.css', 'sass/style.scss' ), true ) ) {
 			$theme_headers = array(
 				'Theme Name'  => $this->theme['name'],
 				'Theme URI'   => esc_url_raw( $this->theme['uri'] ),


### PR DESCRIPTION
The `$local_filename` variable passed to `do_replacements` includes the local `sass/` directory