### PR TITLE
Made changes to change the readme.txt

### DIFF
--- a/plugins/underscoresme-generator/underscoresme-generator.php
+++ b/plugins/underscoresme-generator/underscoresme-generator.php
@@ -213,7 +213,7 @@ class Underscores_Generator_Plugin {
 		
 		//Special treatment for readme.txt
 		if ( 'readme.txt' == $filename ) {
-			$contents = preg_replace('/(?<=Description ==) *.*?(.*(?=(== Installation)))/s', '<p>'.$this->theme['description'].'</p>', $contents );
+			$contents = preg_replace('/(?<=Description ==) *.*?(.*(?=(== Installation)))/s', "\n\n" . $this->theme['description'] . "\n\n", $contents );
 			$contents = str_replace( '_s, or underscores', $this->theme['name'], $contents );
 		}
 

--- a/plugins/underscoresme-generator/underscoresme-generator.php
+++ b/plugins/underscoresme-generator/underscoresme-generator.php
@@ -210,6 +210,12 @@ class Underscores_Generator_Plugin {
 			$contents = str_replace( 'Automattic', $this->theme['author'], $contents );
 			$contents = preg_replace( "#printf\\((\\s?__\\(\\s?'Theme:[^,]+,[^,]+,)([^,]+),#", sprintf( "printf(\\1 '%s',", esc_attr( $this->theme['name'] ) ), $contents );
 		}
+		
+		//Special treatment for readme.txt
+		if ( 'readme.txt' == $filename ) {
+			$contents = preg_replace('/(?<=Description ==) *.*?(.*(?=(== Installation)))/s', '<p>'.$this->theme['description'].'</p>', $contents );
+			$contents = str_replace( '_s, or underscores', $this->theme['name'], $contents );
+		}
 
 		// Function names can not contain hyphens.
 		$slug = str_replace( '-', '_', $this->theme['slug'] );


### PR DESCRIPTION
This removes the description and puts in the theme description as inputted by the underscores.me user. It also removes the awkward ', or underscores' the follows the underscores.me user's theme name above the description.

Currently the readme.txt shows this under the license uri:

A starter theme called _chosen-theme-name_, or underscores.

== Description ==

Hi. I'm a starter theme called _chosen-theme-name_, or underscores, if you like. I'm a theme meant for hacking so don't use me as a Parent Theme. Instead try turning me into the next, most awesome, WordPress theme out there. That's what I'm here for.
