### PR TITLE
Adding .github directory to the directories ignored by the Underscores generator

### DIFF
--- a/plugins/underscoresme-generator/underscoresme-generator.php
+++ b/plugins/underscoresme-generator/underscoresme-generator.php
@@ -120,7 +120,7 @@ class Underscores_Generator_Plugin {
 		$prototype_dir = dirname( __FILE__ ) . '/prototype/';
 
 		$exclude_files = array( '.travis.yml', 'codesniffer.ruleset.xml', '.jscsrc', '.jshintignore', 'CONTRIBUTING.md', '.git', '.svn', '.DS_Store', '.gitignore', '.', '..' );
-		$exclude_directories = array( '.git', '.svn', '.', '..' );
+		$exclude_directories = array( '.git', '.svn', '.github', '.', '..' );
 
 		if ( ! $this->theme['sass'] ) {
 			$exclude_directories[] = 'sass';
@@ -210,7 +210,7 @@ class Underscores_Generator_Plugin {
 			$contents = str_replace( 'Automattic', $this->theme['author'], $contents );
 			$contents = preg_replace( "#printf\\((\\s?__\\(\\s?'Theme:[^,]+,[^,]+,)([^,]+),#", sprintf( "printf(\\1 '%s',", esc_attr( $this->theme['name'] ) ), $contents );
 		}
-		
+
 		// Special treatment for readme.txt
 		if ( 'readme.txt' == $filename ) {
 			$contents = preg_replace('/(?<=Description ==) *.*?(.*(?=(== Installation)))/s', "\n\n" . $this->theme['description'] . "\n\n", $contents );


### PR DESCRIPTION
Adding .github directory to the directories ignored by the Underscores generator

This directory is currently used to house a PR template, part of this _s pull request here: https://github.com/Automattic/_s/pull/1143

When that is merged into _s, it will need to be ignored by the generator, so it doesn't inadvertently end up in people's themes.