### PR TITLE
Add Full-Width Page Template to Starter Theme

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -153,3 +153,8 @@ function underscoresme_get_contributors() {
 
 	return (array) $contributors;
 }
+
+function theme_name_enqueue_styles() {
+    wp_enqueue_style('theme-name-style', get_stylesheet_uri());
+}
+add_action('wp_enqueue_scripts', 'theme_name_enqueue_styles');

--- a/inc/generator.php
+++ b/inc/generator.php
@@ -1,0 +1,3 @@
+// Create the custom full-width page template
+$custom_page_template = "<?php\n/**\n * Template Name: Full-Width Page\n * Template Post Type: page\n *\n * @package $theme_name\n */\n\nget_header(); ?>\n<div id=\"primary\" class=\"content-area\">\n<main id=\"main\" class=\"site-main full-width\">\n<?php\nwhile ( have_posts() ) :\n    the_post();\n    get_template_part( 'template-parts/content', 'page' );\n    if ( comments_open() || get_comments_number() ) {\n        comments_template();\n    }\nendwhile;\n?>\n</main>\n</div>\n<?php get_footer(); ?>";
+file_put_contents( $theme_path . '/page-fullwidth.php', $custom_page_template );

--- a/page-fullwidth.php
+++ b/page-fullwidth.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Template Name: Full-Width Page
+ * Template Post Type: page
+ *
+ * @package Theme_Name
+ */
+
+get_header();
+?>
+
+<div id="primary" class="content-area">
+    <main id="main" class="site-main full-width">
+        <?php
+        while (have_posts()) :
+            the_post();
+            get_template_part('template-parts/content', 'page');
+
+            // If comments are open or there's at least one comment, load the comment template.
+            if (comments_open() || get_comments_number()) {
+                comments_template();
+            }
+        endwhile;
+        ?>
+    </main>
+</div>
+
+<?php
+get_footer();

--- a/style.css
+++ b/style.css
@@ -1108,6 +1108,12 @@ img.size-full {
 #content .gallery-columns-4 .gallery-item img {
 }
 
+/* Full-Width Template */
+.full-width {
+    max-width: 100%;
+    padding: 0 20px;
+}
+
 /* Make sure embeds and iframes fit their containers */
 embed,
 iframe,


### PR DESCRIPTION
This PR introduces a default custom page template (Full-Width Page) to the starter themes generated by underscores.me.

Key Features:

A custom page template (page-fullwidth.php) is included in the theme.
Adds an easy starting point for users to create full-width pages without sidebars.
Adds basic CSS for the full-width layout in style.css.
Updates the generator to include the custom template in all new themes.
Testing Notes:

Generate a new theme via underscores.me.
Verify that page-fullwidth.php is present in the theme directory.
Confirm that the full-width template appears in the WordPress editor's page template dropdown.
Apply the template to a page and check its functionality.